### PR TITLE
Fixes for master-epic @ 6.16-epic1

### DIFF
--- a/arch/ia64/Kconfig
+++ b/arch/ia64/Kconfig
@@ -380,3 +380,10 @@ endmenu
 endif
 
 endmenu
+
+config IA64_UNW_DEBUG
+	bool "Enable IA-64 Unwind Debugging Output"
+	depends on IA64
+	help
+	  If you would like to enable debugging output for unwind, say Y here,
+	  otherwise say N.

--- a/arch/ia64/Kconfig
+++ b/arch/ia64/Kconfig
@@ -306,10 +306,6 @@ config NODES_SHIFT
 	  MAX_NUMNODES will be 2^(This value).
 	  If in doubt, use the default.
 
-config HAVE_ARCH_NODEDATA_EXTENSION
-	def_bool y
-	depends on NUMA
-
 config HAVE_MEMORYLESS_NODES
 	def_bool NUMA
 

--- a/arch/ia64/include/asm/exception.h
+++ b/arch/ia64/include/asm/exception.h
@@ -2,11 +2,18 @@
 #ifndef __ASM_EXCEPTION_H
 #define __ASM_EXCEPTION_H
 
+#include <linux/kprobes.h>
+
 struct pt_regs;
 struct exception_table_entry;
 
+extern int die (const char *str, struct pt_regs *regs, long err);
+extern int die_if_kernel (char *str, struct pt_regs *regs, long err);
 extern void ia64_handle_exception(struct pt_regs *regs,
 				  const struct exception_table_entry *e);
+extern void
+__kprobes ia64_do_page_fault (unsigned long address, unsigned long isr,
+			      struct pt_regs *regs);
 
 #define ia64_done_with_exception(regs)					  \
 ({									  \

--- a/arch/ia64/include/asm/exception.h
+++ b/arch/ia64/include/asm/exception.h
@@ -14,6 +14,18 @@ extern void ia64_handle_exception(struct pt_regs *regs,
 extern void
 __kprobes ia64_do_page_fault (unsigned long address, unsigned long isr,
 			      struct pt_regs *regs);
+extern void
+__kprobes ia64_bad_break (unsigned long break_num, struct pt_regs *regs);
+
+extern struct illegal_op_return
+ia64_illegal_op_fault (unsigned long ec, long arg1, long arg2, long arg3,
+		       long arg4, long arg5, long arg6, long arg7,
+		       struct pt_regs regs);
+
+extern void __kprobes
+ia64_fault (unsigned long vector, unsigned long isr, unsigned long ifa,
+	    unsigned long iim, unsigned long itir, long arg5, long arg6,
+	    long arg7, struct pt_regs regs);
 
 #define ia64_done_with_exception(regs)					  \
 ({									  \

--- a/arch/ia64/include/asm/mmu.h
+++ b/arch/ia64/include/asm/mmu.h
@@ -11,4 +11,6 @@ typedef volatile unsigned long mm_context_t;
 
 typedef unsigned long nv_mm_context_t;
 
+void ia64_mmu_init(void *my_cpu_data);
+
 #endif

--- a/arch/ia64/include/asm/pci.h
+++ b/arch/ia64/include/asm/pci.h
@@ -34,6 +34,10 @@ struct pci_vector_struct {
 #define ARCH_GENERIC_PCI_MMAP_RESOURCE
 #define arch_can_pci_mmap_wc()	1
 
+extern void pci_adjust_legacy_attr(struct pci_bus *bus,
+				   enum pci_mmap_state mmap_type);
+
+
 #define HAVE_PCI_LEGACY
 extern int pci_mmap_legacy_page_range(struct pci_bus *bus,
 				      struct vm_area_struct *vma,

--- a/arch/ia64/include/asm/processor.h
+++ b/arch/ia64/include/asm/processor.h
@@ -655,6 +655,10 @@ enum idle_boot_override {IDLE_NO_OVERRIDE=0, IDLE_HALT, IDLE_FORCE_MWAIT,
 
 void default_idle(void);
 
+void cpu_halt (void);
+/* Used by head.S. */
+void console_print(const char *s);
+
 #endif /* !__ASSEMBLY__ */
 
 #endif /* _ASM_IA64_PROCESSOR_H */

--- a/arch/ia64/include/asm/tlb.h
+++ b/arch/ia64/include/asm/tlb.h
@@ -47,4 +47,6 @@
 
 #include <asm-generic/tlb.h>
 
+extern void ia64_tlb_init (void);
+
 #endif /* _ASM_IA64_TLB_H */

--- a/arch/ia64/kernel/Makefile
+++ b/arch/ia64/kernel/Makefile
@@ -38,6 +38,8 @@ obj-$(CONFIG_INTEL_IOMMU)	+= pci-dma.o
 
 obj-$(CONFIG_ELF_CORE)		+= elfcore.o
 
+cflags-$(CONFIG_IA64_UNW_DEBUG)	+= -DUNW_DEBUG=0
+
 # fp_emulate() expects f2-f5,f16-f31 to contain the user-level state.
 CFLAGS_traps.o  += -mfixed-range=f2-f5,f16-f31
 

--- a/arch/ia64/kernel/acpi.c
+++ b/arch/ia64/kernel/acpi.c
@@ -908,6 +908,3 @@ EXPORT_SYMBOL(acpi_unregister_ioapic);
  */
 int acpi_suspend_lowlevel(void) { return 0; }
 
-void acpi_proc_quirk_mwait_check(void)
-{
-}

--- a/arch/ia64/kernel/asm-offsets.c
+++ b/arch/ia64/kernel/asm-offsets.c
@@ -20,6 +20,8 @@
 #include "../kernel/sigframe.h"
 #include "../kernel/fsyscall_gtod_data.h"
 
+void foo(void);
+
 void foo(void)
 {
 	DEFINE(IA64_TASK_SIZE, sizeof (struct task_struct));

--- a/arch/ia64/kernel/cyclone.c
+++ b/arch/ia64/kernel/cyclone.c
@@ -35,7 +35,7 @@ static struct clocksource clocksource_cyclone = {
         .flags          = CLOCK_SOURCE_IS_CONTINUOUS,
 };
 
-int __init init_cyclone_clock(void)
+static int __init init_cyclone_clock(void)
 {
 	u64 __iomem *reg;
 	u64 base;	/* saved cyclone base address */

--- a/arch/ia64/kernel/cyclone.c
+++ b/arch/ia64/kernel/cyclone.c
@@ -6,6 +6,7 @@
 #include <linux/timex.h>
 #include <linux/clocksource.h>
 #include <linux/io.h>
+#include <asm/cyclone.h>
 
 /* IBM Summit (EXA) Cyclone counter code*/
 #define CYCLONE_CBAR_ADDR 0xFEB00CD0

--- a/arch/ia64/kernel/efi.c
+++ b/arch/ia64/kernel/efi.c
@@ -967,7 +967,7 @@ efi_uart_console_only(void)
  * that is big enough to hold EFI memory map. Make sure this
  * descriptor is at least granule sized so it does not get trimmed
  */
-struct kern_memdesc *
+static struct kern_memdesc *
 find_memmap_space (void)
 {
 	u64	contig_low=0, contig_high=0;

--- a/arch/ia64/kernel/efi.c
+++ b/arch/ia64/kernel/efi.c
@@ -1349,12 +1349,3 @@ vmcore_find_descriptor_size (unsigned long address)
 	return ret;
 }
 #endif
-
-char *efi_systab_show_arch(char *str)
-{
-	if (mps_phys != EFI_INVALID_TABLE_ADDR)
-		str += sprintf(str, "MPS=0x%lx\n", mps_phys);
-	if (hcdp_phys != EFI_INVALID_TABLE_ADDR)
-		str += sprintf(str, "HCDP=0x%lx\n", hcdp_phys);
-	return str;
-}

--- a/arch/ia64/kernel/elfcore.c
+++ b/arch/ia64/kernel/elfcore.c
@@ -6,6 +6,10 @@
 
 #include <asm/elf.h>
 
+Elf64_Half elf_core_extra_phdrs(struct coredump_params *cprm);
+size_t elf_core_extra_data_size(struct coredump_params *cprm);
+int elf_core_write_extra_phdrs(struct coredump_params *cprm, loff_t offset);
+int elf_core_write_extra_data(struct coredump_params *cprm);
 
 Elf64_Half elf_core_extra_phdrs(struct coredump_params *cprm)
 {

--- a/arch/ia64/kernel/iosapic.c
+++ b/arch/ia64/kernel/iosapic.c
@@ -105,6 +105,10 @@
 #define DBG(fmt...)
 #endif
 
+#ifdef CONFIG_KEXEC
+void kexec_disable_iosapic(void);
+#endif
+
 static DEFINE_SPINLOCK(iosapic_lock);
 
 /*

--- a/arch/ia64/kernel/irq.c
+++ b/arch/ia64/kernel/irq.c
@@ -27,6 +27,8 @@
 #include <asm/mca.h>
 #include <asm/xtp.h>
 
+#include "irq.h"
+
 /*
  * 'what should we do if we get a hw irq event on an illegal vector'.
  * each architecture has to answer this themselves.
@@ -128,7 +130,6 @@ static void migrate_irqs(void)
 void fixup_irqs(void)
 {
 	unsigned int irq;
-	extern void ia64_process_pending_intr(void);
 	extern volatile int time_keeper_id;
 
 	/* Mask ITV to disable timer */

--- a/arch/ia64/kernel/irq.h
+++ b/arch/ia64/kernel/irq.h
@@ -1,3 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
+extern void ia64_process_pending_intr(void);
+extern void ia64_handle_irq (ia64_vector vector, struct pt_regs *regs);
+extern void ia64_init_itm(void);
 extern void register_percpu_irq(ia64_vector vec, irq_handler_t handler,
 				unsigned long flags, const char *name);
+extern void fixup_irqs(void);

--- a/arch/ia64/kernel/irq_ia64.c
+++ b/arch/ia64/kernel/irq_ia64.c
@@ -40,6 +40,8 @@
 #include <asm/hw_irq.h>
 #include <asm/tlbflush.h>
 
+#include "irq.h"
+
 #define IRQ_DEBUG	0
 
 #define IRQ_VECTOR_UNASSIGNED	(0)

--- a/arch/ia64/kernel/mca.c
+++ b/arch/ia64/kernel/mca.c
@@ -203,6 +203,10 @@ static int loglevel_save = -1;
 	mlogbuf_finished = 0;				\
 	oops_in_progress = 0;
 
+/* called by ia64_os_mca_virtual_begin in the assembly code. */
+void ia64_mca_handler(struct pt_regs *regs, struct switch_stack *sw,
+		      struct ia64_sal_os_state *sos);
+
 /*
  * Push messages into buffer, print them later if not urgent.
  */
@@ -500,7 +504,7 @@ ia64_mca_log_sal_error_record(int sal_info_type)
  * Return value:
  *      1 on Success (in the table)/ 0 on Failure (not in the  table)
  */
-int
+static int
 search_mca_table (const struct mca_table_entry *first,
                 const struct mca_table_entry *last,
                 unsigned long ip)
@@ -603,7 +607,7 @@ out:
  *  Outputs
  *      None
  */
-void
+static void
 ia64_mca_register_cpev (int cpev)
 {
 	/* Register the CPE interrupt vector with SAL */

--- a/arch/ia64/kernel/mca_drv.c
+++ b/arch/ia64/kernel/mca_drv.c
@@ -42,6 +42,12 @@ static int sal_rec_max = 10000;
 /* from mca_drv_asm.S */
 extern void *mca_handler_bhhook(void);
 
+int __init mca_external_handler_init(void);
+void __exit mca_external_handler_exit(void);
+
+/* called by mca_handler_bhhook in assembly code. */
+void mca_handler_bh(unsigned long paddr, void *iip, unsigned long ipsr);
+
 static DEFINE_SPINLOCK(mca_bh_lock);
 
 typedef enum {

--- a/arch/ia64/kernel/module.c
+++ b/arch/ia64/kernel/module.c
@@ -241,7 +241,7 @@ patch_plt (struct module *mod, struct plt_entry *plt, long target_ip, unsigned l
 	return 0;
 }
 
-unsigned long
+static unsigned long
 plt_target (struct plt_entry *plt)
 {
 	uint64_t b0, b1, *b = (uint64_t *) plt->bundle[1];

--- a/arch/ia64/kernel/process.c
+++ b/arch/ia64/kernel/process.c
@@ -54,6 +54,13 @@
 
 #include "sigframe.h"
 
+void do_notify_resume_user(sigset_t *unused,
+		           struct sigscratch *scr, long in_syscall);
+/* Used by clone2() syscall implementation in entry.S */
+asmlinkage long ia64_clone(unsigned long clone_flags, unsigned long stack_start,
+			   unsigned long stack_size, unsigned long parent_tidptr,
+			   unsigned long child_tidptr, unsigned long tls);
+
 void (*ia64_mark_idle)(int);
 
 unsigned long boot_option_idle_override = IDLE_NO_OVERRIDE;

--- a/arch/ia64/kernel/ptrace.c
+++ b/arch/ia64/kernel/ptrace.c
@@ -30,6 +30,7 @@
 #include <asm/rse.h>
 #include <linux/uaccess.h>
 #include <asm/unwind.h>
+#include <asm/syscall.h>
 
 #include "entry.h"
 

--- a/arch/ia64/kernel/ptrace.c
+++ b/arch/ia64/kernel/ptrace.c
@@ -58,6 +58,16 @@
 # define dprintk(format...)
 #endif
 
+asmlinkage long
+syscall_trace_enter (long arg0, long arg1, long arg2, long arg3,
+		     long arg4, long arg5, long arg6, long arg7,
+		     struct pt_regs regs);
+
+asmlinkage void
+syscall_trace_leave (long arg0, long arg1, long arg2, long arg3,
+		     long arg4, long arg5, long arg6, long arg7,
+		     struct pt_regs regs);
+
 /* Return TRUE if PT was created due to kernel-entry via a system-call.  */
 
 static inline int

--- a/arch/ia64/kernel/sal.c
+++ b/arch/ia64/kernel/sal.c
@@ -34,10 +34,11 @@ static struct {
 	void *gpval;	/* gp value to use */
 } pdesc;
 
-static long
-default_handler (void)
+static struct ia64_sal_retval
+default_handler (u64, ...)
 {
-	return -1;
+	struct ia64_sal_retval s = {.status = -1};
+	return s;
 }
 
 ia64_sal_handler ia64_sal = (ia64_sal_handler) default_handler;

--- a/arch/ia64/kernel/salinfo.c
+++ b/arch/ia64/kernel/salinfo.c
@@ -174,6 +174,8 @@ static DEFINE_SPINLOCK(data_saved_lock);
  */
 int (*salinfo_platform_oemdata)(const u8 *sect_header, u8 **oemdata, u64 *oemdata_size);
 
+void salinfo_log_wakeup(int type, u8 *buffer, u64 size, int irqsafe);
+
 struct salinfo_platform_oemdata_parms {
 	const u8 *efi_guid;
 	u8 **oemdata;

--- a/arch/ia64/kernel/setup.c
+++ b/arch/ia64/kernel/setup.c
@@ -56,6 +56,7 @@
 #include <asm/efi.h>
 #include <asm/mca.h>
 #include <asm/meminit.h>
+#include <asm/mmu.h>
 #include <asm/page.h>
 #include <asm/patch.h>
 #include <asm/processor.h>

--- a/arch/ia64/kernel/signal.c
+++ b/arch/ia64/kernel/signal.c
@@ -39,6 +39,8 @@
 # define GET_SIGSET(k,u)	__get_user((k)->sig[0], &(u)->sig[0])
 #endif
 
+long ia64_rt_sigreturn (struct sigscratch *scr);
+
 static long
 restore_sigcontext (struct sigcontext __user *sc, struct sigscratch *scr)
 {

--- a/arch/ia64/kernel/smp.c
+++ b/arch/ia64/kernel/smp.c
@@ -67,8 +67,6 @@ static DEFINE_PER_CPU_SHARED_ALIGNED(unsigned short [NR_CPUS],
 /* This needs to be cacheline aligned because it is written to by *other* CPUs.  */
 static DEFINE_PER_CPU_SHARED_ALIGNED(unsigned long, ipi_operation);
 
-extern void cpu_halt (void);
-
 static void
 stop_this_cpu(void)
 {

--- a/arch/ia64/kernel/smpboot.c
+++ b/arch/ia64/kernel/smpboot.c
@@ -88,6 +88,7 @@ struct sal_to_os_boot *sal_state_for_booting_cpu = &sal_boot_rendez_state[0];
 #define set_brendez_area(x)
 #endif
 
+int start_secondary (void *unused);
 
 /*
  * ITC synchronization related stuff:
@@ -186,7 +187,7 @@ static void fix_b0_for_bsp(void)
 #endif
 }
 
-void
+static void
 sync_master (void *arg)
 {
 	unsigned long flags, i;
@@ -271,7 +272,7 @@ get_delta (long *rt, long *master)
  * almost perfectly synchronized, but we shouldn't assume that the accuracy is much better
  * than half a micro second or so.
  */
-void
+static void
 ia64_sync_itc (unsigned int master)
 {
 	long i, delta, adj, adjust_latency = 0, done = 0;
@@ -589,6 +590,7 @@ remove_siblinginfo(int cpu)
 
 extern void fixup_irqs(void);
 
+static
 int migrate_platform_irqs(unsigned int cpu)
 {
 	int new_cpei_cpu;

--- a/arch/ia64/kernel/sys_ia64.c
+++ b/arch/ia64/kernel/sys_ia64.c
@@ -23,6 +23,18 @@
 #include <asm/shmparam.h>
 #include <linux/uaccess.h>
 
+asmlinkage long ia64_getpriority (int which, int who);
+asmlinkage unsigned long ia64_brk (unsigned long brk);
+
+asmlinkage unsigned long
+ia64_mremap (unsigned long addr, unsigned long old_len, unsigned long new_len,
+	     unsigned long flags, unsigned long new_addr);
+
+asmlinkage long ia64_clock_getres(const clockid_t which_clock,
+				  struct __kernel_timespec __user *tp);
+
+asmlinkage unsigned long sys_getpagesize (void);
+
 unsigned long
 arch_get_unmapped_area (struct file *filp, unsigned long addr, unsigned long len,
 			unsigned long pgoff, unsigned long flags, vm_flags_t vm_flags)

--- a/arch/ia64/kernel/traps.c
+++ b/arch/ia64/kernel/traps.c
@@ -8,6 +8,7 @@
  * 05/12/00 grao <goutham.rao@intel.com> : added isr in siginfo for SIGFPE
  */
 
+#include <linux/cpu.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/sched/signal.h>

--- a/arch/ia64/kernel/unaligned.c
+++ b/arch/ia64/kernel/unaligned.c
@@ -241,6 +241,8 @@ static u16 fr_info[32]={
 	RSW(f30), RSW(f31)
 };
 
+void ia64_handle_unaligned (unsigned long ifa, struct pt_regs *regs);
+
 /* Invalidate ALAT entry for integer register REGNO.  */
 static void
 invala_gr (int regno)

--- a/arch/ia64/kernel/unwind.c
+++ b/arch/ia64/kernel/unwind.c
@@ -56,16 +56,15 @@
 #define UNW_STATS	0	/* WARNING: this disabled interrupts for long time-spans!! */
 
 #ifdef UNW_DEBUG
-  static unsigned int unw_debug_level = UNW_DEBUG;
-#  define UNW_DEBUG_ON(n)	unw_debug_level >= n
-   /* Do not code a printk level, not all debug lines end in newline */
-#  define UNW_DPRINT(n, ...)  if (UNW_DEBUG_ON(n)) printk(__VA_ARGS__)
-#  undef inline
-#  define inline
-#else /* !UNW_DEBUG */
-#  define UNW_DEBUG_ON(n)  0
-#  define UNW_DPRINT(n, ...)
-#endif /* UNW_DEBUG */
+static unsigned int unw_debug_level = UNW_DEBUG;
+#define UNW_DEBUG_ON(n)	unw_debug_level >= n
+#else
+#define UNW_DEBUG_ON(n)	1
+#endif
+/* Do not code a printk level, not all debug lines end in newline */
+#define UNW_DPRINT(n, ...)  if (UNW_DEBUG_ON(n)) printk(__VA_ARGS__)
+#undef inline
+#define inline
 
 #if UNW_STATS
 # define STAT(x...)	x
@@ -257,7 +256,9 @@ pt_regs_off (unsigned long reg)
 		off = unw.pt_regs_offsets[reg];
 
 	if (off < 0) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: bad scratch reg r%lu\n", __func__, reg);
+#endif
 		off = 0;
 	}
 	return (unsigned long) off;
@@ -268,13 +269,17 @@ get_scratch_regs (struct unw_frame_info *info)
 {
 	if (!info->pt) {
 		/* This should not happen with valid unwind info.  */
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: bad unwind info: resetting info->pt\n", __func__);
+#endif
 		if (info->flags & UNW_FLAG_INTERRUPT_FRAME)
 			info->pt = (unsigned long) ((struct pt_regs *) info->psp - 1);
 		else
 			info->pt = info->sp - 16;
 	}
+#ifdef UNW_DEBUG
 	UNW_DPRINT(3, "unwind.%s: sp 0x%lx pt 0x%lx\n", __func__, info->sp, info->pt);
+#endif
 	return (struct pt_regs *) info->pt;
 }
 
@@ -293,8 +298,10 @@ unw_access_gr (struct unw_frame_info *info, int regnum, unsigned long *val, char
 			*nat = 0;
 			return 0;
 		}
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: trying to access non-existent r%u\n",
 			   __func__, regnum);
+#endif
 		return -1;
 	}
 
@@ -339,11 +346,13 @@ unw_access_gr (struct unw_frame_info *info, int regnum, unsigned long *val, char
 					if ((unsigned long) addr < info->regstk.limit
 					    || (unsigned long) addr >= info->regstk.top)
 					{
+#ifdef UNW_DEBUG
 						UNW_DPRINT(0, "unwind.%s: %p outside of regstk "
 							"[0x%lx-0x%lx)\n",
 							__func__, (void *) addr,
 							info->regstk.limit,
 							info->regstk.top);
+#endif
 						return -1;
 					}
 					if ((unsigned long) nat_addr >= info->regstk.top)
@@ -373,8 +382,10 @@ unw_access_gr (struct unw_frame_info *info, int regnum, unsigned long *val, char
 		if ((unsigned long) addr < info->regstk.limit
 		    || (unsigned long) addr >= info->regstk.top)
 		{
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to access register outside "
 				   "of rbs\n",  __func__);
+#endif
 			return -1;
 		}
 		if ((unsigned long) nat_addr >= info->regstk.top)
@@ -384,8 +395,10 @@ unw_access_gr (struct unw_frame_info *info, int regnum, unsigned long *val, char
 
 	if (write) {
 		if (read_only(addr)) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to write read-only location\n",
 				__func__);
+#endif
 		} else {
 			*addr = *val;
 			if (*nat)
@@ -426,14 +439,18 @@ unw_access_br (struct unw_frame_info *info, int regnum, unsigned long *val, int 
 		break;
 
 	      default:
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: trying to access non-existent b%u\n",
 			   __func__, regnum);
+#endif
 		return -1;
 	}
 	if (write)
 		if (read_only(addr)) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to write read-only location\n",
 				__func__);
+#endif
 		} else
 			*addr = *val;
 	else
@@ -449,8 +466,10 @@ unw_access_fr (struct unw_frame_info *info, int regnum, struct ia64_fpreg *val, 
 	struct pt_regs *pt;
 
 	if ((unsigned) (regnum - 2) >= 126) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: trying to access non-existent f%u\n",
 			   __func__, regnum);
+#endif
 		return -1;
 	}
 
@@ -481,8 +500,10 @@ unw_access_fr (struct unw_frame_info *info, int regnum, struct ia64_fpreg *val, 
 
 	if (write)
 		if (read_only(addr)) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to write read-only location\n",
 				__func__);
+#endif
 		} else
 			*addr = *val;
 	else
@@ -571,15 +592,19 @@ unw_access_ar (struct unw_frame_info *info, int regnum, unsigned long *val, int 
 		break;
 
 	      default:
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: trying to access non-existent ar%u\n",
 			   __func__, regnum);
+#endif
 		return -1;
 	}
 
 	if (write) {
 		if (read_only(addr)) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to write read-only location\n",
 				__func__);
+#endif
 		} else
 			*addr = *val;
 	} else
@@ -599,8 +624,10 @@ unw_access_pr (struct unw_frame_info *info, unsigned long *val, int write)
 
 	if (write) {
 		if (read_only(addr)) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ignoring attempt to write read-only location\n",
 				__func__);
+#endif
 		} else
 			*addr = *val;
 	} else
@@ -699,7 +726,9 @@ decode_abreg (unsigned char abreg, int memory)
 	      default:
 		break;
 	}
+#ifdef UNW_DEBUG
 	UNW_DPRINT(0, "unwind.%s: bad abreg=0x%x\n", __func__, abreg);
+#endif
 	return UNW_REG_LC;
 }
 
@@ -739,7 +768,9 @@ spill_next_when (struct unw_reg_info **regp, struct unw_reg_info *lim, unw_word 
 			return;
 		}
 	}
+#ifdef UNW_DEBUG
 	UNW_DPRINT(0, "unwind.%s: excess spill!\n",  __func__);
+#endif
 }
 
 static inline void
@@ -855,11 +886,16 @@ desc_abi (unsigned char abi, unsigned char context, struct unw_state_record *sr)
 {
 	if (abi == 3 && context == 'i') {
 		sr->flags |= UNW_FLAG_INTERRUPT_FRAME;
+#ifdef UNW_DEBUG
 		UNW_DPRINT(3, "unwind.%s: interrupt frame\n",  __func__);
+#endif
 	}
-	else
+	else {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind%s: ignoring unwabi(abi=0x%x,context=0x%x)\n",
 				__func__, abi, context);
+#endif
+	}
 }
 
 static inline void
@@ -1346,8 +1382,10 @@ static inline void
 script_emit (struct unw_script *script, struct unw_insn insn)
 {
 	if (script->count >= UNW_MAX_SCRIPT_LEN) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: script exceeds maximum size of %u instructions!\n",
 			__func__, UNW_MAX_SCRIPT_LEN);
+#endif
 		return;
 	}
 	script->insn[script->count++] = insn;
@@ -1388,8 +1426,10 @@ emit_nat_info (struct unw_state_record *sr, int i, struct unw_script *script)
 		break;
 
 	      default:
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: don't know how to emit nat info for where = %u\n",
 			   __func__, r->where);
+#endif
 		return;
 	}
 	insn.opc = opc;
@@ -1444,9 +1484,12 @@ compile_reg (struct unw_state_record *sr, int i, struct unw_script *script)
 			opc = UNW_INSN_MOVE_SCRATCH;
 			if (rval <= 11)
 				val = offsetof(struct pt_regs, f6) + 16*(rval - 6);
-			else
+			else {
+#ifdef UNW_DEBUG
 				UNW_DPRINT(0, "unwind.%s: kernel may not touch f%lu\n",
 					   __func__, rval);
+#endif
+			}
 		}
 		break;
 
@@ -1473,8 +1516,10 @@ compile_reg (struct unw_state_record *sr, int i, struct unw_script *script)
 		break;
 
 	      default:
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind%s: register %u has unexpected `where' value of %u\n",
 			   __func__, i, r->where);
+#endif
 		break;
 	}
 	insn.opc = opc;
@@ -1547,10 +1592,14 @@ build_script (struct unw_frame_info *info)
 		r->when = UNW_WHEN_NEVER;
 	sr.pr_val = info->pr;
 
+#ifdef UNW_DEBUG
 	UNW_DPRINT(3, "unwind.%s: ip 0x%lx\n", __func__, ip);
+#endif
 	script = script_new(ip);
 	if (!script) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: failed to create unwind script\n",  __func__);
+#endif
 		STAT(unw.stat.script.build_time += ia64_get_itc() - start);
 		return NULL;
 	}
@@ -1583,8 +1632,10 @@ build_script (struct unw_frame_info *info)
 	}
 	if (!e) {
 		/* no info, return default unwinder (leaf proc, no mem stack, no saved regs)  */
+#ifdef UNW_DEBUG
 		UNW_DPRINT(1, "unwind.%s: no unwind info for ip=0x%lx (prev ip=0x%lx)\n",
 			__func__, ip, unw.cache[info->prev_script].ip);
+#endif
 		sr.curr.reg[UNW_REG_RP].where = UNW_WHERE_BR;
 		sr.curr.reg[UNW_REG_RP].when = -1;
 		sr.curr.reg[UNW_REG_RP].val = 0;
@@ -1632,9 +1683,11 @@ build_script (struct unw_frame_info *info)
 		sr.curr.reg[UNW_REG_RP].where = UNW_WHERE_BR;
 		sr.curr.reg[UNW_REG_RP].when = -1;
 		sr.curr.reg[UNW_REG_RP].val = sr.return_link_reg;
+#ifdef UNW_DEBUG
 		UNW_DPRINT(1, "unwind.%s: using default for rp at ip=0x%lx where=%d val=0x%lx\n",
 			   __func__, ip, sr.curr.reg[UNW_REG_RP].where,
 			   sr.curr.reg[UNW_REG_RP].val);
+#endif
 	}
 
 #ifdef UNW_DEBUG
@@ -1760,8 +1813,10 @@ run_script (struct unw_script *script, struct unw_frame_info *state)
 				s[dst] = (unsigned long) get_scratch_regs(state) + val;
 			} else {
 				s[dst] = 0;
+#ifdef UNW_DEBUG
 				UNW_DPRINT(0, "unwind.%s: no state->pt, dst=%ld, val=%ld\n",
 					   __func__, dst, val);
+#endif
 			}
 			break;
 
@@ -1770,8 +1825,10 @@ run_script (struct unw_script *script, struct unw_frame_info *state)
 				s[dst] = (unsigned long) &unw.r0;
 			else {
 				s[dst] = 0;
+#ifdef UNW_DEBUG
 				UNW_DPRINT(0, "unwind.%s: UNW_INSN_MOVE_CONST bad val=%ld\n",
 					   __func__, val);
+#endif
 			}
 			break;
 
@@ -1840,7 +1897,9 @@ find_save_locs (struct unw_frame_info *info)
 	if ((info->ip & (local_cpu_data->unimpl_va_mask | 0xf)) || info->ip < TASK_SIZE) {
 		/* don't let obviously bad addresses pollute the cache */
 		/* FIXME: should really be level 0 but it occurs too often. KAO */
+#ifdef UNW_DEBUG
 		UNW_DPRINT(1, "unwind.%s: rejecting bad ip=0x%lx\n", __func__, info->ip);
+#endif
 		info->rp_loc = NULL;
 		return -1;
 	}
@@ -1851,9 +1910,11 @@ find_save_locs (struct unw_frame_info *info)
 		scr = build_script(info);
 		if (!scr) {
 			spin_unlock_irqrestore(&unw.lock, flags);
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0,
 				   "unwind.%s: failed to locate/build unwind script for ip %lx\n",
 				   __func__, info->ip);
+#endif
 			return -1;
 		}
 		have_write_lock = 1;
@@ -1896,22 +1957,28 @@ unw_unwind (struct unw_frame_info *info)
 	/* validate the return IP pointer */
 	if (!unw_valid(info, info->rp_loc)) {
 		/* FIXME: should really be level 0 but it occurs too often. KAO */
+#ifdef UNW_DEBUG
 		UNW_DPRINT(1, "unwind.%s: failed to locate return link (ip=0x%lx)!\n",
 			   __func__, info->ip);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
 	/* restore the ip */
 	ip = info->ip = *info->rp_loc;
 	if (ip < GATE_ADDR) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(2, "unwind.%s: reached user-space (ip=0x%lx)\n", __func__, ip);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
 
 	/* validate the previous stack frame pointer */
 	if (!unw_valid(info, info->pfs_loc)) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: failed to locate ar.pfs!\n", __func__);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
@@ -1927,13 +1994,17 @@ unw_unwind (struct unw_frame_info *info)
 			num_regs = *info->cfm_loc & 0x7f;		/* size of frame */
 		info->pfs_loc =
 			(unsigned long *) (info->pt + offsetof(struct pt_regs, ar_pfs));
+#ifdef UNW_DEBUG
 		UNW_DPRINT(3, "unwind.%s: interrupt_frame pt 0x%lx\n", __func__, info->pt);
+#endif
 	} else
 		num_regs = (*info->cfm_loc >> 7) & 0x7f;	/* size of locals */
 	info->bsp = (unsigned long) ia64_rse_skip_regs((unsigned long *) info->bsp, -num_regs);
 	if (info->bsp < info->regstk.limit || info->bsp > info->regstk.top) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: bsp (0x%lx) out of range [0x%lx-0x%lx]\n",
 			__func__, info->bsp, info->regstk.limit, info->regstk.top);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
@@ -1941,15 +2012,19 @@ unw_unwind (struct unw_frame_info *info)
 	/* restore the sp: */
 	info->sp = info->psp;
 	if (info->sp < info->memstk.top || info->sp > info->memstk.limit) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: sp (0x%lx) out of range [0x%lx-0x%lx]\n",
 			__func__, info->sp, info->memstk.top, info->memstk.limit);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
 
 	if (info->ip == prev_ip && info->sp == prev_sp && info->bsp == prev_bsp) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: ip, sp, bsp unchanged; stopping here (ip=0x%lx)\n",
 			   __func__, ip);
+#endif
 		STAT(unw.stat.api.unwind_time += ia64_get_itc() - start; local_irq_restore(flags));
 		return -1;
 	}
@@ -1975,8 +2050,10 @@ unw_unwind_to_user (struct unw_frame_info *info)
 		unw_get_sp(info, &sp);
 		if ((long)((unsigned long)info->task + IA64_STK_OFFSET - sp)
 		    < IA64_PT_REGS_SIZE) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: ran off the top of the kernel stack\n",
 				   __func__);
+#endif
 			break;
 		}
 		if (unw_is_intr_frame(info) &&
@@ -1984,15 +2061,19 @@ unw_unwind_to_user (struct unw_frame_info *info)
 			return 0;
 		if (unw_get_pr (info, &pr) < 0) {
 			unw_get_rp(info, &ip);
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: failed to read "
 				   "predicate register (ip=0x%lx)\n",
 				__func__, ip);
+#endif
 			return -1;
 		}
 	} while (unw_unwind(info) >= 0);
 	unw_get_ip(info, &ip);
+#ifdef UNW_DEBUG
 	UNW_DPRINT(0, "unwind.%s: failed to unwind to user-level (ip=0x%lx)\n",
 		   __func__, ip);
+#endif
 	return -1;
 }
 EXPORT_SYMBOL(unw_unwind_to_user);
@@ -2036,6 +2117,7 @@ init_frame_info (struct unw_frame_info *info, struct task_struct *t,
 	info->sw  = sw;
 	info->sp = info->psp = stktop;
 	info->pr = sw->pr;
+#ifdef UNW_DEBUG
 	UNW_DPRINT(3, "unwind.%s:\n"
 		   "  task   0x%lx\n"
 		   "  rbs = [0x%lx-0x%lx)\n"
@@ -2045,6 +2127,7 @@ init_frame_info (struct unw_frame_info *info, struct task_struct *t,
 		   "  sp     0x%lx\n",
 		   __func__, (unsigned long) t, rbslimit, rbstop, stktop, stklimit,
 		   info->pr, (unsigned long) info->sw, info->sp);
+#endif
 	STAT(unw.stat.api.init_time += ia64_get_itc() - start; local_irq_restore(flags));
 }
 
@@ -2058,11 +2141,13 @@ unw_init_frame_info (struct unw_frame_info *info, struct task_struct *t, struct 
 	sol = (*info->cfm_loc >> 7) & 0x7f;
 	info->bsp = (unsigned long) ia64_rse_skip_regs((unsigned long *) info->regstk.top, -sol);
 	info->ip = sw->b0;
+#ifdef UNW_DEBUG
 	UNW_DPRINT(3, "unwind.%s:\n"
 		   "  bsp    0x%lx\n"
 		   "  sol    0x%lx\n"
 		   "  ip     0x%lx\n",
 		   __func__, info->bsp, sol, info->ip);
+#endif
 	find_save_locs(info);
 }
 
@@ -2073,7 +2158,9 @@ unw_init_from_blocked_task (struct unw_frame_info *info, struct task_struct *t)
 {
 	struct switch_stack *sw = (struct switch_stack *) (t->thread.ksp + 16);
 
+#ifdef UNW_DEBUG
 	UNW_DPRINT(1, "unwind.%s\n", __func__);
+#endif
 	unw_init_frame_info(info, t, sw);
 }
 EXPORT_SYMBOL(unw_init_from_blocked_task);
@@ -2102,8 +2189,10 @@ unw_add_unwind_table (const char *name, unsigned long segment_base, unsigned lon
 	unsigned long flags;
 
 	if (end - start <= 0) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: ignoring attempt to insert empty unwind table\n",
 			   __func__);
+#endif
 		return NULL;
 	}
 
@@ -2133,15 +2222,19 @@ unw_remove_unwind_table (void *handle)
 	long index;
 
 	if (!handle) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: ignoring attempt to remove non-existent unwind table\n",
 			   __func__);
+#endif
 		return;
 	}
 
 	table = handle;
 	if (table == &unw.kernel_table) {
+#ifdef UNW_DEBUG
 		UNW_DPRINT(0, "unwind.%s: sorry, freeing the kernel's unwind table is a "
 			   "no-can-do!\n", __func__);
+#endif
 		return;
 	}
 
@@ -2153,8 +2246,10 @@ unw_remove_unwind_table (void *handle)
 			if (prev->next == table)
 				break;
 		if (!prev) {
+#ifdef UNW_DEBUG
 			UNW_DPRINT(0, "unwind.%s: failed to find unwind table %p\n",
 				   __func__, (void *) table);
+#endif
 			spin_unlock_irqrestore(&unw.lock, flags);
 			return;
 		}

--- a/arch/ia64/kernel/unwind.c
+++ b/arch/ia64/kernel/unwind.c
@@ -1638,7 +1638,7 @@ build_script (struct unw_frame_info *info)
 	}
 
 #ifdef UNW_DEBUG
-	UNW_DPRINT(1, "unwind.%s: state record for func 0x%lx, t=%u:\n",
+	UNW_DPRINT(1, "unwind.%s: state record for func 0x%llx, t=%u:\n",
 		__func__, table->segment_base + e->start_offset, sr.when_target);
 	for (r = sr.curr.reg; r < sr.curr.reg + UNW_NUM_REGS; ++r) {
 		if (r->where != UNW_WHERE_NONE || r->when != UNW_WHEN_NEVER) {

--- a/arch/ia64/kernel/unwind.c
+++ b/arch/ia64/kernel/unwind.c
@@ -238,6 +238,8 @@ static struct {
 #endif
 };
 
+asmlinkage long sys_getunwind (void __user *buf, size_t buf_size);
+
 static inline int
 read_only (void *addr)
 {

--- a/arch/ia64/lib/checksum.c
+++ b/arch/ia64/lib/checksum.c
@@ -15,6 +15,7 @@
 #include <linux/string.h>
 
 #include <asm/byteorder.h>
+#include <asm/checksum.h>
 
 static inline unsigned short
 from64to16 (unsigned long x)

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -627,9 +627,10 @@ int __meminit vmemmap_populate(unsigned long start, unsigned long end, int node,
 {
 	return vmemmap_populate_basepages(start, end, node, NULL);
 }
-
+#ifdef CONFIG_MEMORY_HOTPLUG
 void vmemmap_free(unsigned long start, unsigned long end,
 		struct vmem_altmap *altmap)
 {
 }
 #endif
+#endif /* CONFIG_SPARSEMEM_VMEMMAP */

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -608,19 +608,6 @@ void __init paging_init(void)
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
 }
 
-pg_data_t * __init arch_alloc_nodedata(int nid)
-{
-	unsigned long size = compute_pernodesize(nid);
-
-	return memblock_alloc(size, SMP_CACHE_BYTES);
-}
-
-void arch_refresh_nodedata(int update_node, pg_data_t *update_pgdat)
-{
-	pgdat_list[update_node] = update_pgdat;
-	scatter_node_data();
-}
-
 #ifdef CONFIG_SPARSEMEM_VMEMMAP
 int __meminit vmemmap_populate(unsigned long start, unsigned long end, int node,
 		struct vmem_altmap *altmap)

--- a/arch/ia64/mm/extable.c
+++ b/arch/ia64/mm/extable.c
@@ -10,6 +10,7 @@
 #include <asm/extable.h>
 #include <asm/errno.h>
 #include <asm/processor.h>
+#include <asm/exception.h>
 
 void
 ia64_handle_exception (struct pt_regs *regs, const struct exception_table_entry *e)

--- a/arch/ia64/mm/fault.c
+++ b/arch/ia64/mm/fault.c
@@ -19,8 +19,6 @@
 #include <asm/processor.h>
 #include <asm/exception.h>
 
-extern int die(char *, struct pt_regs *, long);
-
 /*
  * Return TRUE if ADDRESS points at a page in the kernel's mapped segment
  * (inside region 5, on ia64) and that page is present.

--- a/arch/ia64/mm/hugetlbpage.c
+++ b/arch/ia64/mm/hugetlbpage.c
@@ -91,16 +91,6 @@ int prepare_hugepage_range(struct file *file,
 	return 0;
 }
 
-int pmd_huge(pmd_t pmd)
-{
-	return 0;
-}
-
-int pud_huge(pud_t pud)
-{
-	return 0;
-}
-
 void hugetlb_free_pgd_range(struct mmu_gather *tlb,
 			unsigned long addr, unsigned long end,
 			unsigned long floor, unsigned long ceiling)

--- a/arch/ia64/mm/init.c
+++ b/arch/ia64/mm/init.c
@@ -12,6 +12,7 @@
 #include <linux/dmar.h>
 #include <linux/efi.h>
 #include <linux/elf.h>
+#include <linux/initrd.h>
 #include <linux/memblock.h>
 #include <linux/mm.h>
 #include <linux/sched/signal.h>

--- a/arch/ia64/mm/init.c
+++ b/arch/ia64/mm/init.c
@@ -40,8 +40,6 @@
 #include <asm/unistd.h>
 #include <asm/mca.h>
 
-extern void ia64_tlb_init (void);
-
 unsigned long MAX_DMA_ADDRESS = PAGE_OFFSET + 0x100000000UL;
 
 struct page *zero_page_memmap_ptr;	/* map entry for zero page */

--- a/arch/ia64/pci/pci.c
+++ b/arch/ia64/pci/pci.c
@@ -323,7 +323,7 @@ int pcibios_root_bridge_prepare(struct pci_host_bridge *bridge)
 	return 0;
 }
 
-void pcibios_fixup_device_resources(struct pci_dev *dev)
+static void pcibios_fixup_device_resources(struct pci_dev *dev)
 {
 	int idx;
 
@@ -339,7 +339,6 @@ void pcibios_fixup_device_resources(struct pci_dev *dev)
 		pci_claim_resource(dev, idx);
 	}
 }
-EXPORT_SYMBOL_GPL(pcibios_fixup_device_resources);
 
 static void pcibios_fixup_bridge_resources(struct pci_dev *dev)
 {

--- a/drivers/acpi/acpica/tbprint.c
+++ b/drivers/acpi/acpica/tbprint.c
@@ -94,15 +94,7 @@ acpi_tb_print_table_header(acpi_physical_address address,
 			   struct acpi_table_header *header)
 {
 	struct acpi_table_header local_header;
-
-	if (ACPI_COMPARE_NAMESEG(header->signature, ACPI_SIG_FACS)) {
-
-		/* FACS only has signature and length fields */
-
-		ACPI_INFO(("%-4.4s 0x%8.8X%8.8X %06X",
-			   header->signature, ACPI_FORMAT_UINT64(address),
-			   header->length));
-	} else if (ACPI_VALIDATE_RSDP_SIG(ACPI_CAST_PTR(struct acpi_table_rsdp,
+	if (ACPI_VALIDATE_RSDP_SIG(ACPI_CAST_PTR(struct acpi_table_rsdp,
 							header)->signature)) {
 
 		/* RSDP has no common fields */
@@ -121,6 +113,13 @@ acpi_tb_print_table_header(acpi_physical_address address,
 			   ACPI_CAST_PTR(struct acpi_table_rsdp,
 					 header)->revision,
 			   local_header.oem_id));
+	} else if (ACPI_COMPARE_NAMESEG(header->signature, ACPI_SIG_FACS)) {
+
+		/* FACS only has signature and length fields */
+
+		ACPI_INFO(("%-4.4s 0x%8.8X%8.8X %06X",
+			   header->signature, ACPI_FORMAT_UINT64(address),
+			   header->length));
 	} else {
 		/* Standard ACPI table with full common header */
 

--- a/drivers/acpi/processor_idle.c
+++ b/drivers/acpi/processor_idle.c
@@ -695,8 +695,9 @@ static int __cpuidle acpi_idle_enter(struct cpuidle_device *dev,
 		}
 	}
 
-	if (cx->type == ACPI_STATE_C3)
-		ACPI_FLUSH_CPU_CACHE();
+	if (cx->type == ACPI_STATE_C3) {
+		ACPI_FLUSH_CPU_CACHE()
+	}
 
 	acpi_idle_do_entry(cx);
 

--- a/drivers/char/agp/i460-agp.c
+++ b/drivers/char/agp/i460-agp.c
@@ -297,7 +297,7 @@ static int i460_insert_memory_small_io_page (struct agp_memory *mem,
 	int i, j, k, num_entries;
 	void *temp;
 
-	pr_debug("i460_insert_memory_small_io_page(mem=%p, pg_start=%ld, type=%d, paddr0=0x%lx)\n",
+	pr_debug("i460_insert_memory_small_io_page(mem=%p, pg_start=%ld, type=%d, paddr0=0x%llx)\n",
 		 mem, pg_start, type, page_to_phys(mem->pages[0]));
 
 	if (type >= AGP_USER_TYPES || mem->type >= AGP_USER_TYPES)

--- a/drivers/iommu/intel/Kconfig
+++ b/drivers/iommu/intel/Kconfig
@@ -11,7 +11,7 @@ config DMAR_DEBUG
 
 config INTEL_IOMMU
 	bool "Support for Intel IOMMU using DMA Remapping Devices"
-	depends on PCI_MSI && ACPI && (X86 || IA64)
+	depends on PCI_MSI && ACPI && X86
 	select IOMMU_API
 	select IOMMU_IOVA
 	select IOMMU_IOPF

--- a/mm/mm_init.c
+++ b/mm/mm_init.c
@@ -1645,7 +1645,10 @@ void __init *memmap_alloc(phys_addr_t size, phys_addr_t align,
 static void __init alloc_node_mem_map(struct pglist_data *pgdat)
 {
 	unsigned long __maybe_unused start = 0;
+	unsigned long __maybe_unused size = 0;
+	unsigned long __maybe_unused end = 0;
 	unsigned long __maybe_unused offset = 0;
+	struct page *map = NULL;
 
 	/* Skip empty nodes */
 	if (!pgdat->node_spanned_pages)


### PR DESCRIPTION
This pull request contains build fixes for issues found whilst building against the master-epic @ 6.16-epic1 with `CONFIG_WERROR` enabled:

- mm_init: add missing variables in alloc_node_mem_map
- i460-agp: use the correct format type for paddr0
- ia64/treewide: properly declare funtion prototypes
- ia64: declare prototypes in <asm/processor.h>
- ia64/traps: declare prototypes in asm/exception.h
- ia64/irq: declare prototypes in local "irq.h"
- ia64: declare die() and pgfault handler in asm/exception.h
- ia64: declare ia64_mmu_init() prototype in asm/mmu.h
- ia64/lib: include <asm/checksum.h> for prototypes
- ia64/mm: declare ia64_tlb_init() in <asm/tlb.h>
- ia64/mm: include initrd.h for free_initrd_mem()
- ia64/pci: make pcibios_fixup_device_resources local
- ia64/efi: mark find_memmap_space() as static
- ia64/mca: add prototype for externally used functions
- ia64/efi: remove efi_systab_show_arch()
- ia64/mm: drop CONFIG_HAVE_ARCH_NODEDATA_EXTENSION
- ia64/mm: remove already deprecated pXd_huge()
- acpica: swap the header comprasion order in tbprint
- ia64: unwind: properly guard UNW_DPRINT calls with UNW_DEBUG
- ia64: sal: Dirtily fix build on new gcc
- ia64: unwind: correct typed argument for UNW_DPRINT()
- ia64: add prototype declaration for `void pci_adjust_legacy_attr()'
- ACPI: processor_idle: Fix build with CONFIG_WERROR
- ia64: cyclone: add missing asm/cyclone.h
- ia64: ptrace: add missing <asm/syscall.h> in ptrace.c
- ia64: declare non-prototyped functions as static
- ia64/mm: Make vmemmap_free() available only with CONFIG_MEMORY_HOTPLUG
- iommu: mark INTEL_IOMMU as X86-specific

This kernel has been built and boot tested on a HP Integrity rx2660 with `defconfig` and configuration from T2/SDE, with a caveat that `CONFIG_NR_CPUS` must be set to <= 64, lest the system reboots on boot whilst triggering an MCE:

See https://github.com/linux-ia64/linux-ia64/issues/3.