### PR TITLE
Master epic build fixes for v6.18-rc1

### DIFF
--- a/arch/ia64/hp/common/sba_iommu.c
+++ b/arch/ia64/hp/common/sba_iommu.c
@@ -818,7 +818,7 @@ static void mark_clean(void *addr, size_t size)
 
 	while (left >= folio_size(folio)) {
 		left -= folio_size(folio);
-		set_bit(PG_arch_1, &folio->flags);
+		set_bit(PG_arch_1, &folio->flags.f);
 		if (!left)
 			break;
 		folio = folio_next(folio);

--- a/arch/ia64/include/asm/cacheflush.h
+++ b/arch/ia64/include/asm/cacheflush.h
@@ -15,7 +15,7 @@
 #define ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE 1
 static inline void flush_dcache_folio(struct folio *folio)
 {
-	clear_bit(PG_arch_1, &folio->flags);
+	clear_bit(PG_arch_1, &folio->flags.f);
 }
 #define flush_dcache_folio flush_dcache_folio
 

--- a/arch/ia64/kernel/asm-offsets.c
+++ b/arch/ia64/kernel/asm-offsets.c
@@ -5,6 +5,7 @@
  * to extract and format the required data.
  */
 
+#define COMPILE_OFFSETS
 #define ASM_OFFSETS_C 1
 
 #include <linux/sched/signal.h>

--- a/arch/ia64/mm/init.c
+++ b/arch/ia64/mm/init.c
@@ -54,11 +54,11 @@ __ia64_sync_icache_dcache (pte_t pte)
 	folio = page_folio(pte_page(pte));
 	addr = (unsigned long)folio_address(folio);
 
-	if (test_bit(PG_arch_1, &folio->flags))
+	if (test_bit(PG_arch_1, &folio->flags.f))
 		return;				/* i-cache is already coherent with d-cache */
 
 	flush_icache_range(addr, addr + folio_size(folio));
-	set_bit(PG_arch_1, &folio->flags);	/* mark page as clean */
+	set_bit(PG_arch_1, &folio->flags.f);	/* mark page as clean */
 }
 
 /*


### PR DESCRIPTION
The [linux mainline autobuilds](https://github.com/johnny-mnemonic/linux-mainline-autobuilds/actions) haven't failed since 2025-10-03 and last minute regressions were only seldomly introduced so close to the end of a merge window in the past. So it might be a good time to make this PR now.

The changes in this PR will fix build regressions detected during the merge window for v6.18 by replaying some upstream changes also for ia64. They should be applied **after** v6.18-rc1 was merged to master-epic. The feature branch can be rebased as soon as that happened. If you want to adapt the commit messages, please do.

I added my signed-of-by with my Johnny Mnemonic identity which is allowed as per https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d4563201f33a022fc0353033d9dfeb1606a88330 .

****

* Apart from these changes a revert of [the removal of ia64 specific code](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3c716487936aa54083c130d46ad5747769695e09) was needed for me.

* And I also recently noticed some currently not harmful issue during builds:

```
[...]
  CC [M]  drivers/ata/pata_cmd64x.mod.o
ia64-linux-objcopy: vmlinux: section `.data..percpu' can't be allocated in segment 0
LOAD: .text __mca_table .data..patch.phys_stack_reg .IA_64.unwind_info .IA_64.unwind .rodata .pci_fixup __ksymtab __ksymtab_gpl __kcrctab __kcrctab_gpl __ksymtab_strings __param __modver __ex_table .notes .opd .init.text .init.data .data..patch.vtop .data..patch.rse .data..patch.mckinley_e9 .data..page_aligned .data..percpu .data .got .sdata .sbss .bss
  CC [M]  drivers/ata/ata_generic.mod.o
[...]
```

...from https://github.com/johnny-mnemonic/linux-mainline-autobuilds/actions/runs/18438255891/job/52534866480#step:7:4199 .

This was introduced by https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=3e86e4d74c0490e5fc5a7f8de8f29e7579c9ffe5 which is part of a series. This has no effect during runtime AFAICT, as kernels work the same on real machines (tested on all real machines from [here](http://epic-linux.org/#!/machines/) except for the BL860c) w/o and with that commit reverted.

****

There was also https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=337bf13aa9ddab8ae47f2677ab75cf69ae33437b which required changes to "Revert "arch: Remove Itanium (IA-64) architecture"". I'm unsure, but this might have an effect for glass console users on ia64 machines, as for example my used [kernel config](http://epic-linux.org/testing-effort/kernel-configs/linux-for-hp-integrities-v7) does neither select `CONFIG_SCREEN_INFO` nor `CONFIG_SYSFB` which selects `(CONFIG_)SCREEN_INFO` as per https://github.com/torvalds/linux/blob/e406d57be7bd2a4e73ea512c1ae36a40a44e499e/drivers/firmware/Kconfig#L181 . I didn't notice any difference during testing but I also use the serial console via telnet for all machines tested. This should be tested by someone using a glass console. If it regresses with v6.18-rc1, the above mentioned kernel config options might help.
