### PR TITLE
ia64: Disable non-working check

### DIFF
--- a/arch/ia64/mm/fault.c
+++ b/arch/ia64/mm/fault.c
@@ -118,10 +118,12 @@ retry:
 
 	/* OK, we've got a good vm_area for this memory area.  Check the access permissions: */
 
+#if 0
 #	if (((1 << VM_READ_BIT) != VM_READ || (1 << VM_WRITE_BIT) != VM_WRITE) \
 	    || (1 << VM_EXEC_BIT) != VM_EXEC)
 #		error File is out of sync with <linux/mm.h>.  Please update.
 #	endif
+#endif
 
 	if (((isr >> IA64_ISR_R_BIT) & 1UL) && (!(vma->vm_flags & (VM_READ | VM_WRITE))))
 		goto bad_area;


### PR DESCRIPTION
The change in this PR will fix a build regression detected during the merge window for v6.19 by deactivating a due to the upstream commit anyhow not working check. It should be applied after v6.19-rc1 was merged to master-epic. The feature branch can be rebased as soon as that happened. If you want to adapt the commit messages, please do. No replays needed this time for builds.

****

The commit message has most of the details. This is so far a workaround and works both for build and runtime (tested again just today on a rx2620 and in Ski). A proper fix might be to just remove that check, as it might be no longer needed with the definitions centralized in `include/linux/mm.h`. But the question remains, why it is there in the first place. And IIRC it was there since start of [torvalds/linux](https://github.com/torvalds/linux/), see https://github.com/torvalds/linux/blame/v6.6/arch/ia64/mm/fault.c#L123. In any case, if you come up with a proper solution, there's no need to pull that.