### PR TITLE
Master epic updates for v7.0 rc1

### DIFF
--- a/arch/ia64/include/asm/pgtable.h
+++ b/arch/ia64/include/asm/pgtable.h
@@ -397,7 +397,6 @@ pte_same (pte_t a, pte_t b)
 #define update_mmu_cache(vma, address, ptep) do { } while (0)
 
 extern pgd_t swapper_pg_dir[PTRS_PER_PGD];
-extern void paging_init (void);
 
 /*
  * Encode/decode swap entries and swap PTEs. Swap PTEs are all PTEs that
@@ -444,8 +443,7 @@ static inline pte_t pte_swp_clear_exclusive(pte_t pte)
  * for zero-mapped memory areas etc..
  */
 extern unsigned long empty_zero_page[PAGE_SIZE/sizeof(unsigned long)];
-extern struct page *zero_page_memmap_ptr;
-#define ZERO_PAGE(vaddr) (zero_page_memmap_ptr)
+#define ZERO_PAGE(vaddr)	(virt_to_page(ia64_imva(empty_zero_page)))
 
 /* We provide our own get_unmapped_area to cope with VA holes for userland */
 #define HAVE_ARCH_UNMAPPED_AREA

--- a/arch/ia64/kernel/setup.c
+++ b/arch/ia64/kernel/setup.c
@@ -643,7 +643,6 @@ setup_arch (char **cmdline_p)
 #endif
 
 	screen_info_setup();
-	paging_init();
 
 	clear_sched_clock_stable();
 }

--- a/arch/ia64/mm/contig.c
+++ b/arch/ia64/mm/contig.c
@@ -186,6 +186,17 @@ static void __init verify_gap_absence(void)
 		      (max_gap >> 20));
 }
 
+void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
+{
+	unsigned long max_dma;
+
+	max_dma = virt_to_phys((void *) MAX_DMA_ADDRESS) >> PAGE_SHIFT;
+	max_zone_pfns[ZONE_DMA32] = max_dma;
+	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
+
+	verify_gap_absence();
+}
+
 /*
  * Set up the page tables.
  */
@@ -193,16 +204,10 @@ static void __init verify_gap_absence(void)
 void __init
 paging_init (void)
 {
-	unsigned long max_dma;
 	unsigned long max_zone_pfns[MAX_NR_ZONES];
 
 	memset(max_zone_pfns, 0, sizeof(max_zone_pfns));
-	max_dma = virt_to_phys((void *) MAX_DMA_ADDRESS) >> PAGE_SHIFT;
-	max_zone_pfns[ZONE_DMA32] = max_dma;
-	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
-
-	verify_gap_absence();
-
+	arch_zone_limits_init(max_zone_pfns);
 	free_area_init(max_zone_pfns);
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
 }

--- a/arch/ia64/mm/contig.c
+++ b/arch/ia64/mm/contig.c
@@ -198,16 +198,11 @@ void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
 }
 
 /*
- * Set up the page tables.
+ * Initialize the kernel's zero page.
  */
 
 void __init
 paging_init (void)
 {
-	unsigned long max_zone_pfns[MAX_NR_ZONES];
-
-	memset(max_zone_pfns, 0, sizeof(max_zone_pfns));
-	arch_zone_limits_init(max_zone_pfns);
-	free_area_init(max_zone_pfns);
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
 }

--- a/arch/ia64/mm/contig.c
+++ b/arch/ia64/mm/contig.c
@@ -196,13 +196,3 @@ void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
 
 	verify_gap_absence();
 }
-
-/*
- * Initialize the kernel's zero page.
- */
-
-void __init
-paging_init (void)
-{
-	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
-}

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -602,13 +602,7 @@ void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
  */
 void __init paging_init(void)
 {
-	unsigned long max_zone_pfns[MAX_NR_ZONES];
-
 	sparse_init();
-
-	memset(max_zone_pfns, 0, sizeof(max_zone_pfns));
-	arch_zone_limits_init(max_zone_pfns);
-	free_area_init(max_zone_pfns);
 
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
 }

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -594,16 +594,11 @@ void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
 	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
 }
 
-/**
- * paging_init - setup page tables
- *
- * paging_init() sets up the page tables for each node of the system and frees
- * the bootmem allocator memory for general use.
+/*
+ * Initialize the kernel's zero page.
  */
 void __init paging_init(void)
 {
-	sparse_init();
-
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
 }
 

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -585,6 +585,15 @@ void call_pernode_memory(unsigned long start, unsigned long len, void *arg)
 	}
 }
 
+void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
+{
+	unsigned long max_dma;
+
+	max_dma = virt_to_phys((void *) MAX_DMA_ADDRESS) >> PAGE_SHIFT;
+	max_zone_pfns[ZONE_DMA32] = max_dma;
+	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
+}
+
 /**
  * paging_init - setup page tables
  *
@@ -593,16 +602,12 @@ void call_pernode_memory(unsigned long start, unsigned long len, void *arg)
  */
 void __init paging_init(void)
 {
-	unsigned long max_dma;
 	unsigned long max_zone_pfns[MAX_NR_ZONES];
-
-	max_dma = virt_to_phys((void *) MAX_DMA_ADDRESS) >> PAGE_SHIFT;
 
 	sparse_init();
 
 	memset(max_zone_pfns, 0, sizeof(max_zone_pfns));
-	max_zone_pfns[ZONE_DMA32] = max_dma;
-	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
+	arch_zone_limits_init(max_zone_pfns);
 	free_area_init(max_zone_pfns);
 
 	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));

--- a/arch/ia64/mm/discontig.c
+++ b/arch/ia64/mm/discontig.c
@@ -594,14 +594,6 @@ void __init arch_zone_limits_init(unsigned long *max_zone_pfns)
 	max_zone_pfns[ZONE_NORMAL] = max_low_pfn;
 }
 
-/*
- * Initialize the kernel's zero page.
- */
-void __init paging_init(void)
-{
-	zero_page_memmap_ptr = virt_to_page(ia64_imva(empty_zero_page));
-}
-
 #ifdef CONFIG_SPARSEMEM_VMEMMAP
 int __meminit vmemmap_populate(unsigned long start, unsigned long end, int node,
 		struct vmem_altmap *altmap)

--- a/arch/ia64/mm/init.c
+++ b/arch/ia64/mm/init.c
@@ -42,9 +42,6 @@
 
 unsigned long MAX_DMA_ADDRESS = PAGE_OFFSET + 0x100000000UL;
 
-struct page *zero_page_memmap_ptr;	/* map entry for zero page */
-EXPORT_SYMBOL(zero_page_memmap_ptr);
-
 void
 __ia64_sync_icache_dcache (pte_t pte)
 {


### PR DESCRIPTION
The changes in this PR will fix both a build regression due to [the recent mm changes](https://github.com/torvalds/linux/commit/4cff5c05e076d2ee4e34122aa956b84a2eaac587) and also provide a solution for the problem detected for Ski (i.e. userland programs can no longer be executed successfully, see commit 4). The changes were tested to work for both Ski and real machines (rx2620, rx4640, rx2660, rx6600 and rx2800 i2).

They should be applied after v7.0-rc1 was merged to master-epic. The feature branch can be rebased as soon as that happened. Hopefully there won't be any last-minute regressions, but so far things look good.
